### PR TITLE
remove variable letsencrypt_create_private_keys

### DIFF
--- a/roles/letsencrypt/README.md
+++ b/roles/letsencrypt/README.md
@@ -61,7 +61,6 @@ Currently the role only supports the InternetX autodns API. Feel free to contrib
 | email_address                       | yes      |         | mail address which is used for the certificate (reminder mails are sent here)
 | **configuration options**           |          |         |
 | private_key_content                 | no       |         | content of the created private key for the certificate (allows reuse of keys)
-| letsencrypt_create_private_keys     | no       | false   | create private keys
 | letsencrypt_do_http_challenge       | yes      | false   | use http challenge
 | letsencrypt_do_dns_challenge        | yes      | false   | use dns challenge
 | letsencrypt_use_acme_live_directory | no       | false   | choose if production certificates should be created, the staging directory of LE will be used by default
@@ -161,7 +160,6 @@ ansible-playbook playbooks/letsencrypt.yml --ask-vault
       email_address: "ssl-admin@example.com"
       subject_alt_name:
         - domain2.example.com
-    letsencrypt_create_private_keys: true
     letsencrypt_do_http_challenge: true
     letsencrypt_do_dns_challenge: false
     letsencrypt_use_acme_live_directory: false
@@ -193,7 +191,6 @@ ansible-playbook playbooks/letsencrypt.yml --ask-vault
       email_address: "ssl-admin@example.com"
       subject_alt_name:
         - "example.com"
-    letsencrypt_create_private_keys: true
     letsencrypt_do_http_challenge: false
     letsencrypt_do_dns_challenge: true
     letsencrypt_use_acme_live_directory: false

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -18,8 +18,6 @@
 
 - name: run certificate generation
   include: create-keys.yml
-  when:
-    - letsencrypt_create_private_keys | bool
 
 - name: do http challenge
   include: http-challenge.yml


### PR DESCRIPTION
ansibles openssl_privatekey module seems to just check if key is present but not for its content. therefore it does not recreate the key even if variable would be set to true. anyone who wants to set/create the key for themself can do this but it is not neccessary anymore