### PR TITLE
let domain.subject_alt_name use domain.common_name by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,33 @@
 # Changelog
 
-## [0.0.2](https://github.com/T-Systems-MMS/ansible-collection-letsencrypt/tree/0.0.2) (2020-11-06)
+## [0.0.4](https://github.com/T-Systems-MMS/ansible-collection-letsencrypt/tree/0.0.4) (2020-11-12)
 
-[Full Changelog](https://github.com/T-Systems-MMS/ansible-collection-letsencrypt/compare/0.0.1...0.0.2)
+[Full Changelog](https://github.com/T-Systems-MMS/ansible-collection-letsencrypt/compare/0.0.3...0.0.4)
+
+**Implemented enhancements:**
+
+- add description of force\_renewal variable [\#12](https://github.com/T-Systems-MMS/ansible-collection-letsencrypt/pull/12) ([avalor1](https://github.com/avalor1))
+
+**Merged pull requests:**
+
+- update checkout version for release workflow [\#11](https://github.com/T-Systems-MMS/ansible-collection-letsencrypt/pull/11) ([avalor1](https://github.com/avalor1))
+- update checkout version in galaxy push workflow [\#10](https://github.com/T-Systems-MMS/ansible-collection-letsencrypt/pull/10) ([avalor1](https://github.com/avalor1))
+
+## [0.0.3](https://github.com/T-Systems-MMS/ansible-collection-letsencrypt/tree/0.0.3) (2020-11-12)
+
+[Full Changelog](https://github.com/T-Systems-MMS/ansible-collection-letsencrypt/compare/0.0.2...0.0.3)
 
 **Closed issues:**
 
 - Remove unwanted files from release-tarball  [\#4](https://github.com/T-Systems-MMS/ansible-collection-letsencrypt/issues/4)
+
+**Merged pull requests:**
+
+- Add Azure dns provider challenge [\#8](https://github.com/T-Systems-MMS/ansible-collection-letsencrypt/pull/8) ([michaelamattes](https://github.com/michaelamattes))
+
+## [0.0.2](https://github.com/T-Systems-MMS/ansible-collection-letsencrypt/tree/0.0.2) (2020-11-06)
+
+[Full Changelog](https://github.com/T-Systems-MMS/ansible-collection-letsencrypt/compare/0.0.1...0.0.2)
 
 **Merged pull requests:**
 

--- a/roles/letsencrypt/README.md
+++ b/roles/letsencrypt/README.md
@@ -68,6 +68,7 @@ wildcard-certificates use base name again as otherwise DNS txt record creation c
 | letsencrypt_do_dns_challenge        | yes      | false   | use dns challenge
 | letsencrypt_use_acme_live_directory | no       | false   | choose if production certificates should be created, the staging directory of LE will be used by default
 | azure_resource_group                | no       |         | Azure Resource Group for zone_name
+| force_renewal                       | no       |         | Force renewal of certificate
 
 ## Variables for HTTP challenge
 

--- a/roles/letsencrypt/tasks/dns-challenge.yml
+++ b/roles/letsencrypt/tasks/dns-challenge.yml
@@ -5,7 +5,7 @@
     privatekey_path: "{{ private_key_path }}"
     email_address: "{{ domain.email_address }}"
     common_name: "{{ domain.common_name }}"
-    subject_alt_name: "DNS:{{ domain.subject_alt_name | join(',DNS:') }}"
+    subject_alt_name: "DNS:{{ (domain.subject_alt_name | default(domain.common_name) ) | join(',DNS:') }}"
   when:
     - domain.subject_alt_name.top_level is undefined and domain.subject_alt_name.second_level is undefined
 - name: Create CSR for certificate

--- a/roles/letsencrypt/tasks/http-challenge.yml
+++ b/roles/letsencrypt/tasks/http-challenge.yml
@@ -13,7 +13,7 @@
     privatekey_path: "{{ private_key_path }}"
     email_address: "{{ domain.email_address }}"
     common_name: "{{ domain.common_name }}"
-    subject_alt_name: "DNS:{{ domain.subject_alt_name | join(',DNS:') }}"
+    subject_alt_name: "DNS:{{ (domain.subject_alt_name | default(domain.common_name) ) | join(',DNS:') }}"
 
 - name: Create a challenge for {{ domain.common_name }} using a account key file.
   acme_certificate:


### PR DESCRIPTION
the subject_alt_name should not be optional. now it takes domain.common_name by default for subject_alt_name if domain.subject_alt_name is not defined
https://github.com/T-Systems-MMS/ansible-collection-letsencrypt/issues/9