### PR TITLE
add second checkout to solve race condition (version gets updated but…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,12 @@ jobs:
           name: T-Systems MMS
           email: frage@t-systems-mms.com
 
+      # do a second checkout to prevent race situation
+      # changelog gets updated but action works on old commit id
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+
       - name: Generate changelog for the release
         uses: charmixer/auto-changelog-action@8095796
         with:


### PR DESCRIPTION
… release draft is done on old commit id without the adjusted changelog)