### PR TITLE
fix ansible error if group is empty

### DIFF
--- a/roles/letsencrypt/tasks/letsencrypt_preconditions.yml
+++ b/roles/letsencrypt/tasks/letsencrypt_preconditions.yml
@@ -20,3 +20,8 @@
   loop:
     - "{{ letsencrypt_conf_dir }}"
     - "{{ letsencrypt_cert_dir }}"
+
+- name: set fact for letsencrypt_conf_dir_group
+  set_fact:
+    letsencrypt_conf_dir_group: "{{ letsencrypt_conf_dir_user }}"
+  when: letsencrypt_conf_dir_group | length == 0


### PR DESCRIPTION
Issue: 
* change of group in task _create challenge file with common domain for s3 upload_ raise an error

Error: 
```
TASK [letsencrypt : create challenge file with common domain for s3 upload]
*******************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "checksum": "9d000871b167c75bb83cc3ad4438334bd30c14de", "gid": 0, "group": "root", "mode": "0644", "msg": "chgrp failed: failed to look up group ", "owner": "root", "path": "./acme-challenge.example.com", "size": 87, "state": "file", "uid": 0}
```

check env variable group on the system:
```
root@git01 $> env | grep GROUP
root@git01 $>

root@git01 $> env | grep USER
root@git01$> USER=root
```