### PR TITLE
remove letsencrypt_create_private_keys variable from examples

### DIFF
--- a/examples/SAN_example.com.yml
+++ b/examples/SAN_example.com.yml
@@ -12,7 +12,6 @@
         - example.com
         - domain1.example.com
         - domain2.example.com
-    letsencrypt_create_private_keys: true
     letsencrypt_do_http_challenge: true
     letsencrypt_do_dns_challenge: false
     letsencrypt_use_acme_live_directory: false

--- a/examples/wildcard.example.com.yml
+++ b/examples/wildcard.example.com.yml
@@ -11,7 +11,6 @@
       email_address: "ssl-admin@example.com"
       subject_alt_name:
         - "example.com"
-    letsencrypt_create_private_keys: true
     letsencrypt_do_http_challenge: false
     letsencrypt_do_dns_challenge: true
     letsencrypt_dns_provider: autodns

--- a/examples/www.example.com.yml
+++ b/examples/www.example.com.yml
@@ -10,7 +10,6 @@
       email_address: "ssl-admin@example.com"
       subject_alt_name:
         - example.com
-    letsencrypt_create_private_keys: true
     letsencrypt_do_http_challenge: true
     letsencrypt_do_dns_challenge: false
     letsencrypt_use_acme_live_directory: false


### PR DESCRIPTION
remove letsencrypt_create_private_keys variable from examples as it is no longer needed