### PR TITLE
remove common_name variable

### DIFF
--- a/examples/SAN_example.com.yml
+++ b/examples/SAN_example.com.yml
@@ -5,7 +5,6 @@
   vars:
     domain:
       certificate_name: "example.com"
-      common_name: "www.example.com"
       zone: "example.com"
       email_address: "ssl-admin@example.com"
       subject_alt_name:
@@ -43,7 +42,6 @@
     convert_cert_to: pfx
     domain:
       certificate_name: "example.com"
-      common_name: "www.example.com"
       zone: "example.com"
       email_address: "ssl-admin@example.com"
       subject_alt_name:

--- a/examples/wildcard.example.com.yml
+++ b/examples/wildcard.example.com.yml
@@ -6,7 +6,6 @@
   vars:
     domain:
       certificate_name: "wildcard.example.com"
-      common_name: "*.example.com"
       zone: "example.com"
       email_address: "ssl-admin@example.com"
       subject_alt_name:
@@ -41,7 +40,6 @@
     domain:
       email_address: "ssl-admin@example.com"
       certificate_name: "wildcard.example.com"
-      common_name: "*.example.com"
       zone: "example.com"
       subject_alt_name:
         top_level:

--- a/examples/www.example.com.yml
+++ b/examples/www.example.com.yml
@@ -5,7 +5,6 @@
   vars:
     domain:
       certificate_name: "example.com"
-      common_name: "www.example.com"
       zone: "example.com"
       email_address: "ssl-admin@example.com"
       subject_alt_name:

--- a/roles/letsencrypt/README.md
+++ b/roles/letsencrypt/README.md
@@ -55,7 +55,6 @@ Currently the role supports the InternetX autodns API and the Azure DNS API. Fee
 |-------------------------------------|----------|---------|------------
 | **domain configuration**
 | certificate_name                    | yes      |         | name of the resulting certificate. Most useful for wildcard certificates to not have files named '*.example.com' on the filesystem
-| common_name                         | yes      |         | domain for which the certificate will be created, non wildcards are also possible
 | zone                                | yes      |         | zone in which the dns records should be created
 | subject_alt_name                    | yes      |         | if you want to use
 wildcard-certificates use base name again as otherwise DNS txt record creation could fail
@@ -163,7 +162,6 @@ ansible-playbook playbooks/letsencrypt.yml --ask-vault
   vars:
     domain:
       certificate_name: "domain1.example.com"
-      common_name: "domain1.example.com"
       zone: "example.com"
       email_address: "ssl-admin@example.com"
       subject_alt_name:
@@ -194,7 +192,6 @@ ansible-playbook playbooks/letsencrypt.yml --ask-vault
   vars:
     domain:
       certificate_name: "wildcard.example.com"
-      common_name: "*.example.com"
       zone: "example.com"
       email_address: "ssl-admin@example.com"
       subject_alt_name:

--- a/roles/letsencrypt/tasks/dns-challenge-autodns.yml
+++ b/roles/letsencrypt/tasks/dns-challenge-autodns.yml
@@ -15,29 +15,6 @@
           }
       register: login
 
-    - name: add a new TXT record to the common domain
-      uri:
-        url: "https://api.autodns.com/v1/zone/{{ domain.zone }}/a.ns14.net"
-        method: PATCH
-        body_format: json
-        body:
-          {
-            "origin": "{{ domain.zone }}",
-            "resourceRecordsAdd": [
-              {
-                "name": "_acme-challenge",
-                "ttl": 60,
-                "type": "TXT",
-                "value": "{{ challenge['challenge_data'][domain.common_name]['dns-01']['resource_value'] }}"
-              }
-            ]
-          }
-        headers:
-          Cookie: "{{ login.set_cookie }}"
-      when:
-        # only runs if the challenge is run the first time, because then there is challenge_data
-        - challenge['challenge_data'][domain.common_name] is defined
-
     - name: add a new TXT record to the SAN domains
       uri:
         url: "https://api.autodns.com/v1/zone/{{ domain.zone }}/a.ns14.net"
@@ -78,29 +55,6 @@
         terms_agreed: true
         remaining_days: "{{ remaining_days }}"
         data: "{{ challenge }}"
-
-    - name: remove created TXT record to keep DNS zone clean
-      uri:
-        url: "https://api.autodns.com/v1/zone/{{ domain.zone }}/a.ns14.net"
-        method: PATCH
-        body_format: json
-        body:
-          {
-            "origin": "{{ domain.zone }}",
-            "resourceRecordsRem": [
-              {
-                "name": "_acme-challenge",
-                "ttl": 60,
-                "type": "TXT",
-                "value": "{{ challenge['challenge_data'][domain.common_name]['dns-01']['resource_value'] }}"
-              }
-            ]
-          }
-        headers:
-          Cookie: "{{ login.set_cookie }}"
-      when:
-        # only runs if the challenge is run the first time, because then there is challenge_data
-        - challenge['challenge_data'][domain.common_name] is defined
 
     - name: remove created SAN TXT records to keep DNS zone clean
       uri:

--- a/roles/letsencrypt/tasks/dns-challenge-azure.yml
+++ b/roles/letsencrypt/tasks/dns-challenge-azure.yml
@@ -3,7 +3,7 @@
 - name: add a new TXT record to the SAN top-level domains
   azure_rm_dnsrecordset:
     resource_group: "{{ azure_resource_group }}"
-    relative_name: "{{ '_acme-challenge' if item == item.split('.')[-2:] | join('.') else '_acme-challenge.' + item.split('.')[:-2] | join('.') }}"
+    relative_name: "{{ '_acme-challenge' }}{{ '' if item | replace('*.','') == (item.split('.')[-2:] | join('.')) else '.' }}{{ (item | replace('*.','')).split('.')[:-2] | join('.') }}"
     zone_name: "{{ item.split('.')[-2:] | join('.') }}"
     record_mode: append
     state: present
@@ -17,7 +17,7 @@
 - name: add a new TXT record to the SAN second-level domains
   azure_rm_dnsrecordset:
     resource_group: "{{ azure_resource_group }}"
-    relative_name: "{{ '_acme-challenge' if item == item.split('.')[-3:] | join('.') else '_acme-challenge.' + item.split('.')[:-3] | join('.') }}"
+    relative_name: "{{ '_acme-challenge' }}{{ '' if item | replace('*.','') == (item.split('.')[-3:] | join('.')) else '.' }}{{ (item | replace('*.','')).split('.')[:-3] | join('.') }}"
     zone_name: "{{ item.split('.')[-3:] | join('.') }}"
     record_mode: append
     state: present
@@ -46,7 +46,7 @@
 - name: remove created SAN top-level TXT records to keep DNS zone clean
   azure_rm_dnsrecordset:
     resource_group: "{{ azure_resource_group }}"
-    relative_name: "{{ '_acme-challenge' if item == item.split('.')[-2:] | join('.') else '_acme-challenge.' + item.split('.')[:-2] | join('.') }}"
+    relative_name: "{{ '_acme-challenge' }}{{ '' if item | replace('*.','') == (item.split('.')[-2:] | join('.')) else '.' }}{{ (item | replace('*.','')).split('.')[:-2] | join('.') }}"
     zone_name: "{{ item.split('.')[-2:] | join('.') }}"
     state: absent
     record_type: TXT
@@ -58,7 +58,7 @@
 - name: remove created SAN second-level TXT records to keep DNS zone clean
   azure_rm_dnsrecordset:
     resource_group: "{{ azure_resource_group }}"
-    relative_name: "{{ '_acme-challenge' if item == item.split('.')[-3:] | join('.') else '_acme-challenge.' + item.split('.')[:-3] | join('.') }}"
+    relative_name: "{{ '_acme-challenge' }}{{ '' if item | replace('*.','') == (item.split('.')[-3:] | join('.')) else '.' }}{{ (item | replace('*.','')).split('.')[:-3] | join('.') }}"
     zone_name: "{{ item.split('.')[-3:] | join('.') }}"
     state: absent
     record_type: TXT

--- a/roles/letsencrypt/tasks/dns-challenge-azure.yml
+++ b/roles/letsencrypt/tasks/dns-challenge-azure.yml
@@ -1,15 +1,4 @@
 ---
-- name: create TXT record in a new record set
-  azure_rm_dnsrecordset:
-    resource_group: "{{ azure_resource_group }}"
-    relative_name: "_acme-challenge"
-    zone_name: "{{ domain.zone }}"
-    record_mode: append
-    state: present
-    record_type: TXT
-    records:
-      - entry: "{{ challenge['challenge_data'][domain.common_name]['dns-01']['resource_value'] }}"
-
 # split top_level for zone_name and if subdomain is defined add subdomain to relative_name
 - name: add a new TXT record to the SAN top-level domains
   azure_rm_dnsrecordset:
@@ -53,16 +42,6 @@
     terms_agreed: true
     remaining_days: "{{ remaining_days }}"
     data: "{{ challenge }}"
-
-- name: remove created TXT record to keep DNS zone clean
-  azure_rm_dnsrecordset:
-    resource_group: "{{ azure_resource_group }}"
-    relative_name: "_acme-challenge"
-    zone_name: "{{ domain.zone }}"
-    state: absent
-    record_type: TXT
-    records:
-      - entry: "{{ challenge['challenge_data'][domain.common_name]['dns-01']['resource_value'] }}"
 
 - name: remove created SAN top-level TXT records to keep DNS zone clean
   azure_rm_dnsrecordset:

--- a/roles/letsencrypt/tasks/dns-challenge.yml
+++ b/roles/letsencrypt/tasks/dns-challenge.yml
@@ -4,21 +4,20 @@
     path: "{{ csr_path }}"
     privatekey_path: "{{ private_key_path }}"
     email_address: "{{ domain.email_address }}"
-    common_name: "{{ domain.common_name }}"
     subject_alt_name: "DNS:{{ domain.subject_alt_name | join(',DNS:') }}"
   when:
     - domain.subject_alt_name.top_level is undefined and domain.subject_alt_name.second_level is undefined
+
 - name: Create CSR for certificate
   openssl_csr:
     path: "{{ csr_path }}"
     privatekey_path: "{{ private_key_path }}"
     email_address: "{{ domain.email_address }}"
-    common_name: "{{ domain.common_name }}"
     subject_alt_name: "DNS:{{ (domain.subject_alt_name.top_level | default([])) | union(domain.subject_alt_name.second_level | default([])) | join(',DNS:') }}"
   when:
     - domain.subject_alt_name.top_level is defined or domain.subject_alt_name.second_level is defined
 
-- name: Create a challenge for {{ domain.common_name }} using a account key file.
+- name: Create a challenge for {{ domain.certificate_name }} using a account key file.
   acme_certificate:
     account_key_src: "{{ account_key_path }}"
     account_email: "{{ account_email }}"

--- a/roles/letsencrypt/tasks/http-challenge.yml
+++ b/roles/letsencrypt/tasks/http-challenge.yml
@@ -12,10 +12,9 @@
     path: "{{ csr_path }}"
     privatekey_path: "{{ private_key_path }}"
     email_address: "{{ domain.email_address }}"
-    common_name: "{{ domain.common_name }}"
     subject_alt_name: "DNS:{{ domain.subject_alt_name | join(',DNS:') }}"
 
-- name: Create a challenge for {{ domain.common_name }} using a account key file.
+- name: Create a challenge for {{ domain.certificate_name }} using a account key file.
   acme_certificate:
     account_key_src: "{{ account_key_path }}"
     account_email: "{{ account_email }}"
@@ -32,17 +31,6 @@
 - name: validate challenge only if it is created or changed
   when: challenge is changed
   block:
-    - name: create challenge file with common domain for s3 upload
-      copy:
-        dest: "acme-challenge.{{ domain.common_name }}"
-        content: "{{ challenge['challenge_data'][domain.common_name]['http-01']['resource_value'] }}"
-        owner: "{{ letsencrypt_conf_dir_user }}"
-        group: "{{ letsencrypt_conf_dir_group }}"
-      register: challenge_file
-      when:
-        # only runs if the challenge is run the first time, because then there is challenge_data
-        - challenge['challenge_data'][domain.common_name] is defined
-
     - name: create challenge file with SAN domain for s3 upload
       copy:
         dest: "acme-challenge.{{ item }}"
@@ -54,20 +42,6 @@
         - domain.subject_alt_name is defined
         # only runs if the challenge is run the first time, because then there is challenge_data
         - challenge['challenge_data'][item] is defined
-
-    - name: upload challenge file for common domain to s3 bucket
-      aws_s3:
-        aws_access_key: "{{ letsencrypt_s3_access_key }}"
-        aws_secret_key: "{{ letsencrypt_s3_secret_key }}"
-        bucket: "{{ letsencrypt_s3_bucket_name }}"
-        object: "{{ challenge['challenge_data'][domain.common_name]['http-01']['resource'] }}"
-        src: "acme-challenge.{{ domain.common_name }}"
-        mode: "put"
-        region: "{{ letsencrypt_s3_config_region }}"
-        permission: "public-read"
-      when:
-        # only runs if the challenge is run the first time, because then there is challenge_data
-        - challenge['challenge_data'][domain.common_name] is defined
 
     - name: upload challenge file for SAN domain to s3 bucket
       aws_s3:
@@ -102,18 +76,6 @@
         remaining_days: "{{ remaining_days }}"
         data: "{{ challenge }}"
 
-    - name: remove challenge file for common domain from s3 bucket
-      aws_s3:
-        aws_access_key: "{{ letsencrypt_s3_access_key }}"
-        aws_secret_key: "{{ letsencrypt_s3_secret_key }}"
-        bucket: "{{ letsencrypt_s3_bucket_name }}"
-        object: "{{ challenge['challenge_data'][domain.common_name]['http-01']['resource'] }}"
-        mode: "delobj"
-        region: "{{ letsencrypt_s3_config_region }}"
-      when:
-        # only runs if the challenge is run the first time, because then there is challenge_data
-        - challenge['challenge_data'][domain.common_name] is defined
-
     - name: remove challenge file for SAN domain from s3 bucket
       aws_s3:
         aws_access_key: "{{ letsencrypt_s3_access_key }}"
@@ -127,14 +89,6 @@
         - domain.subject_alt_name is defined
         # only runs if the challenge is run the first time, because then there is challenge_data
         - challenge['challenge_data'][item] is defined
-
-    - name: remove challenge file for common domain from fs
-      file:
-        dest: "acme-challenge.{{ domain.common_name }}"
-        state: absent
-      when:
-        # only runs if the challenge is run the first time, because then there is challenge_data
-        - challenge['challenge_data'][domain.common_name] is defined
 
     - name: remove challenge file for SAN domain from fs
       file:


### PR DESCRIPTION
- remove common_name variable as the use of Common Name is deprecated and the recomended way is to use dNSName (https://www.ietf.org/rfc/rfc2818.txt) as mentioned in #9

Tested DNS challenge with AutoDNS and HTTP challenge successfully in internal project "tak"

@michaelamattes please test the implementation for AzureDNS as i do not have the posibility to test it myself and give feedback on this. Thank you! :)