### PR TITLE
fix ansible error if group is empty

### DIFF
--- a/roles/letsencrypt/README.md
+++ b/roles/letsencrypt/README.md
@@ -90,9 +90,7 @@ wildcard-certificates use base name again as otherwise DNS txt record creation c
 
 | Variable                                 | Required | Default                              | Description
 |------------------------------------------|----------|--------------------------------------|------------
-| letsencrypt_conf_dir                     | no       | $HOME                                | overwrite letsencrypt_conf_dir if you want to use a dir which is accessible from multiple users
-| letsencrypt_conf_dir_user                | yes      | $USER                                | you can overwrite letsencrypt_conf_dir_user with a user who should be used when a group readable directory is used
-| letsencrypt_conf_dir_group               | yes      | $GROUP                               | you can overwrite letsencrypt_conf_dir_group with a group which consists of multiple users if ansible role is used in subteams
+| letsencrypt_conf_dir                     | no       | $HOME                                | overwrite letsencrypt_conf_dir if you want to use another directory which is accessible for the user which runs the playbook
 | letsencrypt_prerequisites_packagemanager | yes      | yum                                  | set the packagemanager which is used of the ansible_host. Possible values are all supported package managers from ansible package module
 | acme_staging_directory                   | no       | acme-staging-v02.api.letsencrypt.org | acme directory which will be used for certificate challenge
 | acme_live_directory                      | no       | acme-v02.api.letsencrypt.org         | acme directory which will be used for certificate challenge

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -7,11 +7,6 @@ letsencrypt_use_acme_live_directory: false
 # independend while using the same data
 letsencrypt_conf_dir: "{{ lookup('env','HOME') }}/letsencrypt"
 letsencrypt_cert_dir: "{{ letsencrypt_conf_dir }}/certs"
-## set user and group of conf dirs to values of running user of the playbook
-# overwrite in vars to allow usage of another user
-letsencrypt_conf_dir_user: "{{ lookup('env', 'USER') }}"
-# overwrite in vars to allow usage of another group which may consist of more members
-letsencrypt_conf_dir_group: "{{ lookup('env', 'GROUP') }}"
 # set packagemanager to use for localhost connections (yum, apt)
 letsencrypt_prerequisites_packagemanager: "yum"
 # region for s3 bucket when

--- a/roles/letsencrypt/tasks/http-challenge.yml
+++ b/roles/letsencrypt/tasks/http-challenge.yml
@@ -35,8 +35,7 @@
       copy:
         dest: "acme-challenge.{{ item }}"
         content: "{{ challenge['challenge_data'][item]['http-01']['resource_value'] }}"
-        owner: "{{ letsencrypt_conf_dir_user }}"
-        group: "{{ letsencrypt_conf_dir_group }}"
+        mode: 0640
       loop: "{{ domain.subject_alt_name }}"
       when:
         - domain.subject_alt_name is defined


### PR DESCRIPTION
- remove owner and group setting during creation of challenge file
- set mode for challenge file creation as this should silence the linter (https://ansible-lint.readthedocs.io/en/latest/default_rules.html#file-permissions-unset-or-incorrect)
- remove letsencrypt_conf_dir_(user|group) variable as it is no longer used
- adjusted documentation accordingly