### PR TITLE
fix broken AutoDNS wildcard creation #20

### DIFF
--- a/roles/letsencrypt/tasks/dns-challenge-autodns.yml
+++ b/roles/letsencrypt/tasks/dns-challenge-autodns.yml
@@ -25,7 +25,7 @@
             "origin": "{{ item }}",
             "resourceRecordsAdd": [
               {
-                "name": "_acme-challenge.{{ item }}",
+                "name": "_acme-challenge.{{ item | replace ('*.','') }}",
                 "ttl": 60,
                 "type": "TXT",
                 "value": "{{ challenge['challenge_data'][item]['dns-01']['resource_value'] }}"
@@ -66,7 +66,7 @@
             "origin": "{{ item }}",
             "resourceRecordsRem": [
               {
-                "name": "_acme-challenge.{{ item }}",
+                "name": "_acme-challenge.{{ item | replace ('*.','') }}",
                 "ttl": 60,
                 "type": "TXT",
                 "value": "{{ challenge['challenge_data'][item]['dns-01']['resource_value'] }}"

--- a/roles/letsencrypt/tasks/dns-challenge-autodns.yml
+++ b/roles/letsencrypt/tasks/dns-challenge-autodns.yml
@@ -25,6 +25,10 @@
             "origin": "{{ item }}",
             "resourceRecordsAdd": [
               {
+                # "remove" '*.' from entry when it occurs. without it it would try to create a
+                # record like _acme-challenge.*.example.com which is not allowed by AutoDNS
+                # see: https://jinja.palletsprojects.com/en/master/templates/#replace
+                # and: https://jbmoelker.github.io/jinja-compat-tests/filters/replace/#pattern
                 "name": "_acme-challenge.{{ item | replace ('*.','') }}",
                 "ttl": 60,
                 "type": "TXT",


### PR DESCRIPTION
- remove '\*.' from entry when it occurs. as without it it would try to create a record like _acme-challenge.*.example.com which is not allowed by AutoDNS