### PR TITLE
Simplify challenge provider selection

### DIFF
--- a/docs/dns-challenge/autodns.md
+++ b/docs/dns-challenge/autodns.md
@@ -18,8 +18,6 @@ None
       email_address: "ssl-admin@example.com"
       subject_alt_name:
         - "*.example.com"
-    letsencrypt_do_http_challenge: false
-    letsencrypt_do_dns_challenge: true
     letsencrypt_dns_provider: autodns
     letsencrypt_use_acme_live_directory: false
     account_email: "ssl-admin@example.com"
@@ -32,7 +30,7 @@ None
 ### SAN certificate
 
 ```yaml
-- name: create the certificate for *.example.com
+- name: create the certificate for example.com
   hosts: localhost
   roles:
     - letsencrypt
@@ -45,8 +43,6 @@ None
         - "example.com"
         - "domain1.example.com"
         - "domain2.example.com"
-    letsencrypt_do_http_challenge: false
-    letsencrypt_do_dns_challenge: true
     letsencrypt_dns_provider: autodns
     letsencrypt_use_acme_live_directory: false
     account_email: "ssl-admin@example.com"

--- a/docs/dns-challenge/azure.md
+++ b/docs/dns-challenge/azure.md
@@ -16,8 +16,6 @@
   roles:
     - letsencrypt
   vars:
-    letsencrypt_do_http_challenge: false
-    letsencrypt_do_dns_challenge: true
     letsencrypt_dns_provider: azure
     letsencrypt_use_acme_live_directory: true
     account_email: "ssl-admin@example.com"
@@ -40,8 +38,6 @@
   roles:
     - letsencrypt
   vars:
-    letsencrypt_do_http_challenge: false
-    letsencrypt_do_dns_challenge: true
     letsencrypt_dns_provider: azure
     letsencrypt_use_acme_live_directory: true
     account_email: "ssl-admin@example.com"

--- a/docs/dns-challenge/hetzner.md
+++ b/docs/dns-challenge/hetzner.md
@@ -12,8 +12,6 @@
   roles:
     - letsencrypt
   vars:
-    letsencrypt_do_http_challenge: false
-    letsencrypt_do_dns_challenge: true
     letsencrypt_dns_provider: hetzner
     letsencrypt_use_acme_live_directory: true
     account_email: "ssl-admin@example.com"

--- a/docs/dns-challenge/openstack.md
+++ b/docs/dns-challenge/openstack.md
@@ -16,8 +16,6 @@
   roles:
     - letsencrypt
   vars:
-    letsencrypt_do_http_challenge: false
-    letsencrypt_do_dns_challenge: true
     letsencrypt_dns_provider: openstack
     letsencrypt_use_acme_live_directory: false
     dns_openstack_user_domain: "OTC-EU-DE-00000000001000000000"

--- a/docs/dns-challenge/pebble.md
+++ b/docs/dns-challenge/pebble.md
@@ -23,8 +23,6 @@ This is also done for the provider of the local http-challenge.
       email_address: "ssl-admin@example.com"
       subject_alt_name:
         - "example.com"
-    letsencrypt_do_http_challenge: false
-    letsencrypt_do_dns_challenge: true
     letsencrypt_dns_provider: "pebble"
     letsencrypt_use_acme_live_directory: false
     account_email: "ssl-admin@example.com"

--- a/docs/http-challenge/local.md
+++ b/docs/http-challenge/local.md
@@ -24,9 +24,7 @@ Make sure that the validation-/ hashfile(s) is/are reachable by your configured 
         - example.com
         - domain1.example.com
         - domain2.example.com
-    letsencrypt_do_http_challenge: true
     letsencrypt_http_provider: "local"
-    letsencrypt_do_dns_challenge: false
     letsencrypt_use_acme_live_directory: false
     account_email: "ssl-admin@example.com"
 ```

--- a/docs/http-challenge/s3.md
+++ b/docs/http-challenge/s3.md
@@ -61,9 +61,7 @@ rewrite (\.well-known/acme-challenge.*) https://your-bucket-name.s3.amazonaws.co
         - example.com
         - domain1.example.com
         - domain2.example.com
-    letsencrypt_do_http_challenge: true
     letsencrypt_http_provider: "s3"
-    letsencrypt_do_dns_challenge: false
     letsencrypt_use_acme_live_directory: false
     account_email: "ssl-admin@example.com"
     letsencrypt_s3_bucket_name: "example-ssl-bucket"

--- a/docs/role-letsencrypt.md
+++ b/docs/role-letsencrypt.md
@@ -33,8 +33,6 @@ Feel free to contribute more DNS or HTTP APIs :)
 | **configuration options**           |          |         |
 | account_key_content                 | no       |         | Content of the created letsencrypt account key
 | private_key_content                 | no       |         | Content of the created private key for the certificate (allows reuse of keys)
-| letsencrypt_do_http_challenge       | yes      | false   | Use http challenge
-| letsencrypt_do_dns_challenge        | yes      | false   | Use dns challenge
 | letsencrypt_use_acme_live_directory | no       | false   | Choose if production certificates should be created, the staging directory of LE will be used by default
 | force_renewal                       | no       |         | Force renewal of certificate before `remaining_days` is reached
 

--- a/roles/letsencrypt/defaults/main.yml
+++ b/roles/letsencrypt/defaults/main.yml
@@ -24,6 +24,3 @@ intermediate_path: "{{ letsencrypt_cert_dir }}/{{ domain.certificate_name }}_int
 fullchain_path: "{{ letsencrypt_cert_dir }}/{{ domain.certificate_name }}_fullchain.pem"
 private_key_path: "{{ letsencrypt_cert_dir }}/{{ domain.certificate_name }}.key"
 remaining_days: "30"
-
-letsencrypt_do_http_challenge: false
-letsencrypt_do_dns_challenge: false

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -8,12 +8,12 @@
 - name: do http challenge
   include_tasks: http-challenge.yml
   when:
-    - letsencrypt_do_http_challenge | bool
+    - letsencrypt_http_provider
 
 - name: do dns challenge
   include_tasks: dns-challenge.yml
   when:
-    - letsencrypt_do_dns_challenge | bool
+    - letsencrypt_dns_provider
 
 - name: convert certificate
   include_tasks: convert_certificate.yml

--- a/roles/letsencrypt/tasks/main.yml
+++ b/roles/letsencrypt/tasks/main.yml
@@ -8,12 +8,12 @@
 - name: do http challenge
   include_tasks: http-challenge.yml
   when:
-    - letsencrypt_http_provider
+    - letsencrypt_http_provider is defined
 
 - name: do dns challenge
   include_tasks: dns-challenge.yml
   when:
-    - letsencrypt_dns_provider
+    - letsencrypt_dns_provider is defined
 
 - name: convert certificate
   include_tasks: convert_certificate.yml

--- a/roles/letsencrypt/tasks/preconditions.yml
+++ b/roles/letsencrypt/tasks/preconditions.yml
@@ -2,24 +2,8 @@
 - name: check if a challenge provider is used
   assert:
     that:
-      - letsencrypt_do_dns_challenge | bool or letsencrypt_do_http_challenge | bool
-    fail_msg: "You need to set letsencrypt_do_dns_challenge'' or 'letsencrypt_do_http_challenge'."
-
-- name: check if a DNS challenge provider is used
-  assert:
-    that:
-      - letsencrypt_dns_provider is defined
-    fail_msg: "You need to set a DNS challenge provider ('letsencrypt_dns_provider') if you use the DNS challenge."
-  when:
-    - letsencrypt_do_dns_challenge | bool
-
-- name: check if a HTTP challenge provider is used
-  assert:
-    that:
-      - letsencrypt_http_provider is defined
-    fail_msg: "You need to set a HTTP challenge provider ('letsencrypt_http_provider') if you use the HTTP challenge."
-  when:
-    - letsencrypt_do_http_challenge | bool
+      - letsencrypt_dns_provider or letsencrypt_http_provider
+    fail_msg: "You need to set a 'letsencrypt_dns_provider' or 'letsencrypt_http_provider'."
 
 - name: set fact for acme_directory depending on what is set in letsencrypt_use_acme_live_directory
   set_fact:

--- a/roles/letsencrypt/tasks/preconditions.yml
+++ b/roles/letsencrypt/tasks/preconditions.yml
@@ -2,7 +2,7 @@
 - name: check if a challenge provider is used
   assert:
     that:
-      - letsencrypt_dns_provider or letsencrypt_http_provider
+      - letsencrypt_dns_provider is defined or letsencrypt_http_provider is defined
     fail_msg: "You need to set a 'letsencrypt_dns_provider' or 'letsencrypt_http_provider'."
 
 - name: set fact for acme_directory depending on what is set in letsencrypt_use_acme_live_directory

--- a/tests/integration/targets/letsencrypt/dns-challenge-pebble.yml
+++ b/tests/integration/targets/letsencrypt/dns-challenge-pebble.yml
@@ -11,8 +11,6 @@
       email_address: "ssl-admin@example.com"
       subject_alt_name:
         - "example.com"
-    letsencrypt_do_http_challenge: false
-    letsencrypt_do_dns_challenge: true
     letsencrypt_dns_provider: "pebble"
     letsencrypt_use_acme_live_directory: false
     account_email: "ssl-admin@example.com"

--- a/tests/integration/targets/letsencrypt/http-challenge-local.yml
+++ b/tests/integration/targets/letsencrypt/http-challenge-local.yml
@@ -11,10 +11,8 @@
       email_address: "ssl-admin@example.de"
       subject_alt_name:
         - example.de
-    letsencrypt_do_http_challenge: true
     letsencrypt_http_provider: "local"
     letsencrypt_local_validation_path: "/tmp"
-    letsencrypt_do_dns_challenge: false
     letsencrypt_use_acme_live_directory: false
     account_email: "ssl-admin@example.de"
     acme_staging_directory: "https://localhost:14000/dir"


### PR DESCRIPTION
Change used variable for challenge provider selection to
letsencrypt_*_provider.
Change preconditions check to check if letsencrypt_*_provider variable
is set.
Remove letsencrypt_do_*_challenge variables as they are not used
anymore.
Adjust documentation.